### PR TITLE
Sort modules and definitions (type/interface, uppercase-first, alphabetically)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -36,7 +36,25 @@ const main = pipe(
       .sort((a, b) => a.localeCompare(b))
       .reduce((acc, key) => ({
         ...acc,
-        [key]: root[key].sort((a, b) => a.definitionName.localeCompare(b.definitionName))
+        [key]: root[key].sort((a, b) => {
+          const aIsType = a.definitionKind === "type" || a.definitionKind === "interface";
+          const bIsType = b.definitionKind === "type" || b.definitionKind === "interface";
+
+          if (aIsType !== bIsType) {
+            if (aIsType) return -1;
+            return 1;
+          }
+
+
+          const aIsUpperCase = a.definitionName[0].toUpperCase() === a.definitionName[0];
+          const bIsUpperCase = b.definitionName[0].toUpperCase() === b.definitionName[0];
+
+          if (aIsUpperCase !== bIsUpperCase) {
+            if (aIsUpperCase) return -1;
+            return 1;
+          }
+          return a.definitionName.localeCompare(b.definitionName);
+        })
       }), {})
   ),
   Effect.tap((a) =>

--- a/src/main.ts
+++ b/src/main.ts
@@ -31,6 +31,14 @@ const main = pipe(
       Effect.provideSomeLayer(SerializerLive),
     )
   }),
+  Effect.map(root =>
+    Object.keys(root)
+      .sort((a, b) => a.localeCompare(b))
+      .reduce((acc, key) => ({
+        ...acc,
+        [key]: root[key].sort((a, b) => a.definitionName.localeCompare(b.definitionName))
+      }), {})
+  ),
   Effect.tap((a) =>
     pipe(
       outputFile,


### PR DESCRIPTION
Right now the sorting is random, or perhaps by definition order.
By sorting the modules and definitions, it is easier to read the file and digest change diffs.